### PR TITLE
Overhaul of C++ part for 64bit compilation and double precision

### DIFF
--- a/src/examples/FilesAndFilters/FilesAndFilters.cpp
+++ b/src/examples/FilesAndFilters/FilesAndFilters.cpp
@@ -32,16 +32,16 @@ int main()
 {
 	//Declare class and input variables
 	Persistence1D p;
-	vector<float> data;
-	float currdata; 
+	vector<double> data;
+	double currdata; 
 	ifstream datafile;
 	char * filename = "data.txt";
 	
 	//Declare variables for results
 	vector<TPairedExtrema> pairs;	
-	vector<int> min, max;			
-	int globalMinIndex;
-	float globalMinValue;
+	vector<size_t> min, max;			
+	size_t globalMinIndex;
+	double globalMinValue;
 	
 
 	//Open the data file for reading
@@ -77,7 +77,7 @@ int main()
 		
 	//Now set a threshold for features filtering
 	//In this case, we choose a threshold between largest and smallest persistence, to select from of the data.
-	float filterThreshold = (pairs.front().Persistence + pairs.back().Persistence)/2;
+	double filterThreshold = (pairs.front().Persistence + pairs.back().Persistence)/2;
 	
 	//The vector which hold the data for the Get functions are being reset before use.
 	//Use them to retrieve the filtered results:

--- a/src/examples/MatlabVisualization/MatlabVisualization.cpp
+++ b/src/examples/MatlabVisualization/MatlabVisualization.cpp
@@ -40,8 +40,8 @@ int main()
 {
 	//Input and class variables declaration
 	Persistence1D p;
-	vector<float> data;
-	float currdata; 
+	vector<double> data;
+	double currdata; 
 	ifstream datafile;
 	ofstream outfile;
 	char * filename = "data.txt";
@@ -49,8 +49,8 @@ int main()
 	bool enableMatlabIndexing = true;
 
 	//Output variables declaration
-	vector<int> min, max;			
-	int globalMinIndex;
+	vector<size_t> min, max;			
+	size_t globalMinIndex;
 	
 	//Open and read the data file
 	datafile.open(filename);
@@ -78,7 +78,7 @@ int main()
 	}
 	
 	//Now, set a threshold for features filtering
-	float filterThreshold = 1.0;
+	double filterThreshold = 1.0;
 	
 	//Retrieve the filtered results from the class. 
 	//Since results are intended to be used within Matlab, set MatlabIndexing in all Get function calls
@@ -92,7 +92,7 @@ int main()
 	if (!outfile)
 		return -2;
 	
-	for (unsigned int i = 0; i < min.size() && i < max.size(); i++)
+	for (size_t i = 0; i < min.size() && i < max.size(); i++)
 	{
 		outfile << min[i] << endl;
 		outfile << max[i] << endl;

--- a/src/examples/SimpleDataVector/SimpleDataVector.cpp
+++ b/src/examples/SimpleDataVector/SimpleDataVector.cpp
@@ -28,7 +28,7 @@ using namespace p1d;
 int main()
 {
 	//Create some data
-	vector< float > data;
+	vector<double> data;
 	data.push_back(2.0);   data.push_back(5.0);   data.push_back(7.0);
 	data.push_back(-12.0); data.push_back(-13.0); data.push_back(-7.0);
 	data.push_back(10.0);  data.push_back(18.0);  data.push_back(6.0);

--- a/src/persistence1d/persistence1d.hpp
+++ b/src/persistence1d/persistence1d.hpp
@@ -357,7 +357,7 @@ protected:
 		Only edges of destroyed components are updated to the new component color.
 		The Component values in this vector are invalid at the end of the algorithm.
 	*/
-	std::vector<size_t> Colors;		//need to init to empty
+	std::vector<int> Colors;		//need to init to empty
 
 
 	/*!

--- a/src/persistence1d/persistence1d.hpp
+++ b/src/persistence1d/persistence1d.hpp
@@ -35,10 +35,10 @@ struct TIdxAndData
 	}
 
 	///The index of the vertex within the Data vector. 
-	int Idx;
+	size_t Idx;
 
 	///Vertex data value from the original Data vector sent as an argument to RunPersistence.
-	float Data;
+	double Data;
 };
 
 
@@ -51,14 +51,14 @@ struct TComponent
 	///A component is defined by the indices of its edges.
 	///Both variables hold the respective indices of the vertices in Data vector.
 	///All vertices between them are considered to belong to this component.
-	int LeftEdgeIndex;
-	int RightEdgeIndex;
+	size_t LeftEdgeIndex;
+	size_t RightEdgeIndex;
 
 	///The index of the local minimum within the component as longs as its alive. 
-	int MinIndex;
+	size_t MinIndex;
 
 	///The value of the Data[MinIndex].
-	float MinValue; //redundant, but makes life easier
+	double MinValue; //redundant, but makes life easier
 
 	///Set to true when a component is created. Once components are merged,
 	///the destroyed component Alive value is set to false. 
@@ -74,15 +74,15 @@ struct TComponent
 struct TPairedExtrema
 {
 	///Index of local minimum, as per Data vector.
-	int MinIndex;
+	size_t MinIndex;
 
 	///Index of local maximum, as per Data vector. 
-	int MaxIndex;
+	size_t MaxIndex;
 
 	///The persistence of the two extrema.
 	///Data[MaxIndex] - Data[MinIndex]		 
 	///Guaranteed to be >= 0.
-	float Persistence;	
+	double Persistence;	
 
 	bool operator<(const TPairedExtrema& other) const
 	{
@@ -125,7 +125,7 @@ public:
 
 		@param[in] InputData Vector of data to find features on, ordered according to its axis.
 	*/
-	bool RunPersistence(const std::vector<float>& InputData)
+	bool RunPersistence(const std::vector<double>& InputData)
 	{	
 		Data = InputData; 
 		Init();
@@ -153,7 +153,7 @@ public:
 	void PrintPairs(const std::vector<TPairedExtrema>& pairs) const 
 	{
 		for (std::vector<TPairedExtrema>::const_iterator it = pairs.begin(); 
-			it != pairs.end(); it++)
+			it != pairs.end(); ++it)
 		{
 			std::cout	<< "Persistence: " << (*it).Persistence
 						<< " minimum index: " << (*it).MinIndex
@@ -169,7 +169,7 @@ public:
 		@param[in] threshold		Threshold value for pair persistence.
 		@param[in] matlabIndexing	Use Matlab indexing for printing.
 	*/	
-	void PrintResults(const float threshold = 0.0, const bool matlabIndexing = false) const
+	void PrintResults(const double threshold = 0.0, const bool matlabIndexing = false) const
 	{
 		if (threshold < 0)
 		{
@@ -203,7 +203,7 @@ public:
 		
 		@param[in] matlabIndexing	Set this to true to change all indices of features to Matlab's 1-indexing.
 	*/
-	bool GetPairedExtrema(std::vector<TPairedExtrema> & pairs, const float threshold = 0, const bool matlabIndexing = false) const
+	bool GetPairedExtrema(std::vector<TPairedExtrema> & pairs, const double threshold = 0, const bool matlabIndexing = false) const
 	{
 		//make sure the user does not use previous results that do not match the data
 		pairs.clear();
@@ -218,7 +218,7 @@ public:
 		
 		if (matlabIndexing) //match matlab indices by adding one
 		{
-			for (std::vector<TPairedExtrema>::iterator p = pairs.begin(); p != pairs.end(); p++)
+			for (std::vector<TPairedExtrema>::iterator p = pairs.begin(); p != pairs.end(); ++p)
 			{
 				(*p).MinIndex += MATLAB_INDEX_FACTOR;
 				(*p).MaxIndex += MATLAB_INDEX_FACTOR;			
@@ -238,7 +238,7 @@ public:
 	@param[in]	threshold		Return only indices for pairs whose persistence is greater than or equal to threshold. 
 	@param[in]	matlabIndexing	Set this to true to change all indices to match Matlab's 1-indexing.
 */
-	bool GetExtremaIndices(std::vector<int> & min, std::vector<int> & max, const float threshold = 0, const bool matlabIndexing = false) const
+	bool GetExtremaIndices(std::vector<size_t> & min, std::vector<size_t> & max, const double threshold = 0, const bool matlabIndexing = false) const
 	{
 		//before doing anything, make sure the user does not use old results
 		min.clear();
@@ -249,12 +249,12 @@ public:
 		min.reserve(PairedExtrema.size());
 		max.reserve(PairedExtrema.size());
 		
-		int matlabIndexFactor = 0;
+		size_t matlabIndexFactor = 0;
 		if (matlabIndexing) matlabIndexFactor = MATLAB_INDEX_FACTOR;
 
 		std::vector<TPairedExtrema>::const_iterator lower_bound = FilterByPersistence(threshold);
 
-		for (std::vector<TPairedExtrema>::const_iterator p = lower_bound; p != PairedExtrema.end(); p++)
+		for (std::vector<TPairedExtrema>::const_iterator p = lower_bound; p != PairedExtrema.end(); ++p)
 		{
 			min.push_back((*p).MinIndex + matlabIndexFactor);
 			max.push_back((*p).MaxIndex + matlabIndexFactor);
@@ -266,7 +266,7 @@ public:
 		The global minimum does not get paired and is not returned 
 		via GetPairedExtrema and GetExtremaIndices.
 	*/
-	int GetGlobalMinimumIndex(const bool matlabIndexing = false) const
+	size_t GetGlobalMinimumIndex(const bool matlabIndexing = false) const
 	{
 		if (Components.empty()) return -1;
 
@@ -284,7 +284,7 @@ public:
 		The global minimum does not get paired and is not returned 
 		via GetPairedExtrema and GetExtremaIndices.
 	*/
-	float GetGlobalMinimumValue() const
+	double GetGlobalMinimumValue() const
 	{
 		if (Components.empty()) return 0;
 
@@ -304,12 +304,12 @@ public:
 	bool VerifyResults() 
 	{
 		bool flag = true; 
-		std::vector<int> min, max;
-		std::vector<int> combinedIndices;
+		std::vector<size_t> min, max;
+		std::vector<size_t> combinedIndices;
 		
 		GetExtremaIndices(min, max);
 
-		int globalMinIdx = GetGlobalMinimumIndex();
+		size_t globalMinIdx = GetGlobalMinimumIndex();
 				
 		std::sort(min.begin(), min.end());
 		std::sort(max.begin(), max.end());
@@ -323,11 +323,11 @@ public:
 		   flag = false;
 		}
 
-		if ((globalMinIdx > (int)Data.size()-1) || (globalMinIdx < -1)) flag = false;
+		if ((globalMinIdx > Data.size()-1) || (globalMinIdx < -1)) flag = false;
 		if (globalMinIdx == -1 && min.size() != 0) flag = false;
 		
-		std::vector<int>::iterator minUniqueEnd = std::unique(min.begin(), min.end());
-		std::vector<int>::iterator maxUniqueEnd = std::unique(max.begin(), max.end());
+		std::vector<size_t>::iterator minUniqueEnd = std::unique(min.begin(), min.end());
+		std::vector<size_t>::iterator maxUniqueEnd = std::unique(max.begin(), max.end());
 				
 		if (minUniqueEnd != min.end() ||
 			maxUniqueEnd != max.end() ||
@@ -343,7 +343,7 @@ protected:
 	/*!
 		Contain a copy of the original input data.
 	*/
-	std::vector<float> Data;
+	std::vector<double> Data;
 	
 	
 	/*!
@@ -357,7 +357,7 @@ protected:
 		Only edges of destroyed components are updated to the new component color.
 		The Component values in this vector are invalid at the end of the algorithm.
 	*/
-	std::vector<int> Colors;		//need to init to empty
+	std::vector<size_t> Colors;		//need to init to empty
 
 
 	/*!
@@ -373,7 +373,7 @@ protected:
 	std::vector<TPairedExtrema> PairedExtrema;
 	
 		
-	unsigned int TotalComponents;	//keeps track of component vector size and newest component "color"
+	size_t TotalComponents;	//keeps track of component vector size and newest component "color"
 	bool AliveComponentsVerified;	//Index of global minimum in Data vector. This minimum is never paired.
 	
 	
@@ -386,9 +386,9 @@ protected:
 
 		@param[in] firstIdx,secondIdx	Indices of components to be merged. Their order does not matter. 
 	*/
-	void MergeComponents(const int firstIdx, const int secondIdx)
+	void MergeComponents(const size_t firstIdx, const size_t secondIdx)
 	{
-		int survivorIdx, destroyedIdx;
+		size_t survivorIdx, destroyedIdx;
 		//survivor - component whose hub is bigger
 		if (Components[firstIdx].MinValue < Components[secondIdx].MinValue)
 		{
@@ -435,7 +435,7 @@ protected:
 
 		@param[in] firstIdx, secondIdx Indices of vertices to be paired. Order does not matter. 
 	*/
-	void CreatePairedExtrema(const int firstIdx, const int secondIdx)
+	void CreatePairedExtrema(const size_t firstIdx, const size_t secondIdx)
 	{
 		TPairedExtrema pair; 
 		
@@ -488,7 +488,7 @@ protected:
 
 	@param[in]	minIdx Index of a local minimum. 
 	*/
-	void CreateComponent(const int minIdx)
+	void CreateComponent(const size_t minIdx)
 	{
 		TComponent comp;
 		comp.Alive = true;
@@ -518,7 +518,7 @@ protected:
 		@param[in]	componentIdx	Index of component (the value of a neighboring vertex in Colors[]).
 		@param[in] 	dataIdx			Index of vertex which the component is extended to.
 	*/
-	void ExtendComponent(const int componentIdx, const int dataIdx)
+	void ExtendComponent(const size_t componentIdx, const size_t dataIdx)
 	{
 #ifdef _DEUBG
 		assert(Components[componentIdx].Alive == true)
@@ -538,7 +538,7 @@ protected:
 		{
 #ifdef _DEUBG
 			std::string errorMessage = "ExtendComponent: index mismatch. Data index: ";
-			errorMessage += std::to_string((long long)dataIdx);
+			errorMessage += std::to_string(dataIdx);
 			throw (errorMessage);
 #endif 
 		}
@@ -563,7 +563,7 @@ protected:
 		Colors.resize(Data.size());
 		std::fill(Colors.begin(), Colors.end(), NO_COLOR);
 		
-		int vectorSize = (int)(Data.size()/RESIZE_FACTOR) + 1; //starting reserved size >= 1 at least
+		size_t vectorSize = (size_t)(Data.size()/RESIZE_FACTOR) + 1; //starting reserved size >= 1 at least
 		
 		Components.clear();
 		Components.reserve(vectorSize);
@@ -584,13 +584,13 @@ protected:
 	{
 		if (Data.size()==0) return;
 				
-		for (std::vector<float>::size_type i = 0; i != Data.size(); i++)
+		for (std::vector<double>::size_type i = 0; i != Data.size(); ++i)
 		{
 			TIdxAndData dataidxpair; 
 
 			//this is going to make problems
 			dataidxpair.Data = Data[i]; 
-			dataidxpair.Idx = (int)i; 
+			dataidxpair.Idx = i; 
 
 			SortedData.push_back(dataidxpair);
 		}
@@ -617,9 +617,9 @@ protected:
 			return;
 		}
 
-		for (std::vector<TIdxAndData>::iterator p = SortedData.begin(); p != SortedData.end(); p++)
+		for (std::vector<TIdxAndData>::iterator p = SortedData.begin(); p != SortedData.end(); ++p)
 		{
-			int i = (*p).Idx;
+			size_t i = (*p).Idx;
 
 			//left most vertex - no left neighbor
 			//two options - either local minimum, or extend component
@@ -664,7 +664,7 @@ protected:
 			}
 			else if (Colors[i-1] != NO_COLOR && Colors[i+1] != NO_COLOR) //local maximum - merge components
 			{
-				int leftComp, rightComp; 
+				size_t leftComp, rightComp; 
 
 				leftComp = Colors[i-1];
 				rightComp = Colors[i+1]; 
@@ -702,7 +702,7 @@ protected:
 		
 		@param[in]	threshold	Minimum persistence of features to be returned.		
 	*/
-	std::vector<TPairedExtrema>::const_iterator FilterByPersistence(const float threshold = 0) const
+	std::vector<TPairedExtrema>::const_iterator FilterByPersistence(const double threshold = 0) const
 	{		
 		if (threshold == 0 || threshold < 0) return PairedExtrema.begin();
 
@@ -733,7 +733,7 @@ protected:
 #endif
 		}
 		
-		for (std::vector<TComponent>::const_iterator it = Components.begin()+1; it != Components.end(); it++)
+		for (std::vector<TComponent>::const_iterator it = Components.begin()+1; it != Components.end(); ++it)
 		{
 			if ((*it).Alive == true) 
 			{

--- a/src/persistence1d/persistence1d.hpp
+++ b/src/persistence1d/persistence1d.hpp
@@ -268,7 +268,7 @@ public:
 	*/
 	size_t GetGlobalMinimumIndex(const bool matlabIndexing = false) const
 	{
-		if (Components.empty()) return -1;
+		if (Components.empty()) return 0;
 
 		assert(Components.front().Alive);
 		if (matlabIndexing)
@@ -286,7 +286,7 @@ public:
 	*/
 	double GetGlobalMinimumValue() const
 	{
-		if (Components.empty()) return 0;
+		if (Components.empty()) return 0.0;
 
 		assert(Components.front().Alive);
 		return Components.front().MinValue;
@@ -323,8 +323,8 @@ public:
 		   flag = false;
 		}
 
-		if ((globalMinIdx > Data.size()-1) || (globalMinIdx < -1)) flag = false;
-		if (globalMinIdx == -1 && min.size() != 0) flag = false;
+		if ((globalMinIdx > Data.size()-1) || Components.empty()) flag = false;
+		if (Components.empty() && min.size() != 0) flag = false;
 		
 		std::vector<size_t>::iterator minUniqueEnd = std::unique(min.begin(), min.end());
 		std::vector<size_t>::iterator maxUniqueEnd = std::unique(max.begin(), max.end());

--- a/src/persistence1d/persistence1d_driver.cpp
+++ b/src/persistence1d/persistence1d_driver.cpp
@@ -6,7 +6,7 @@
  *
  *  Command line: persistence1d_driver.exe	\<filename\> [threshold] [-MATLAB]
  *			- filename is the path to a data text file.
- *			  Data is assumed to be formatted as a single float-compatible value per row. 
+ *			  Data is assumed to be formatted as a single double-compatible value per row. 
  *			- [Optional] threshold is a floating point value. Acceptable threshold value >= 0
  *			- [Optional] -MATLAB - output indices match Matlab 1-indexing convention.
  *  Output:	- Indices of extrema, written to a text file, one value per row.
@@ -24,6 +24,7 @@
 
 #include <fstream>
 #include <string>
+#include <cstring>
 
 #define MATLAB "-MATLAB"
 
@@ -32,18 +33,18 @@ using namespace p1d;
 
 
 /*!
-	Tries to open the input file and read its contents to a float vector.
+	Tries to open the input file and read its contents to a double vector.
 	
-	Input is assumed to be formatted as one number per line, in float compatible notation.
+	Input is assumed to be formatted as one number per line, in double compatible notation.
 	
 	Ignores any lines which do not conform to this assumption.
 
 	Number of data entries is assumed to be smaller than vector's class maximum size - this is not checked!
 
-	@param[in] filename		Name of input file with float data.
+	@param[in] filename		Name of input file with double data.
 	@param[out] data		Data is written to this vector.
 */
-bool ReadFileToVector (char * filename, vector<float> & data);
+bool ReadFileToVector (char * filename, vector<double> & data);
 /*!
 	Writes indices of extrema features to file, sorted according to their persistence. 
 
@@ -60,7 +61,7 @@ void WriteMinMaxPairsToFile (char * filename, vector<TPairedExtrema> pairs);
 	Parses user command line.
 	Checks if the user set a threshold value or wants MATLAB indexing.
 */
-bool ParseCmdLine(int argc, char* argv[], float &threshold, bool & matlabIndexing);
+bool ParseCmdLine(int argc, char* argv[], double &threshold, bool & matlabIndexing);
 
 /*!
 	Main function - reads a file specified as a command line argument. runs persistence, 
@@ -72,9 +73,9 @@ bool ParseCmdLine(int argc, char* argv[], float &threshold, bool & matlabIndexin
 */
 int main(int argc, char* argv[])
 {
-	vector<float> data;
+	vector<double> data;
 	vector<int> indices; 
-	float threshold;
+	double threshold;
 	vector <TPairedExtrema> pairs;
 	bool matlabIndexing;
 	Persistence1D p;
@@ -115,7 +116,7 @@ int main(int argc, char* argv[])
 	return 0;
 }
 
-bool ReadFileToVector (char * filename, vector<float> & data)
+bool ReadFileToVector (char * filename, vector<double> & data)
 {
 	ifstream datafile;
 	
@@ -129,7 +130,7 @@ bool ReadFileToVector (char * filename, vector<float> & data)
 		return false;
 	}
 
-	float currdata;
+	double currdata;
 
 	while(datafile >> currdata)
 	{
@@ -152,13 +153,12 @@ void WriteMinMaxPairsToFile (char * filename, vector<TPairedExtrema> pairs)
 	
 	for (vector<TPairedExtrema>::iterator p = pairs.begin(); p != pairs.end(); p++)
 	{
-		datafile << to_string((long long)(*p).MinIndex) << endl;
-		datafile << to_string((long long)(*p).MaxIndex) << endl;
+		datafile << to_string((*p).MinIndex) << " " << to_string((*p).MaxIndex) << " " << to_string((*p).Persistence)<< endl;
 	}
 
 	datafile.close();
 }
-bool ParseCmdLine(int argc, char* argv[], float &threshold, bool & matlabIndexing)
+bool ParseCmdLine(int argc, char* argv[], double &threshold, bool & matlabIndexing)
 {	
 	bool noErrors = true;
 		
@@ -186,7 +186,7 @@ bool ParseCmdLine(int argc, char* argv[], float &threshold, bool & matlabIndexin
 		else if ( argv[counter][0] == '0') //different from nullptr
 		{
 			//this doesn't throw exceptions, AKAIK
-			threshold = (float)atof(argv[counter]);
+			threshold = (double)atof(argv[counter]);
 
 			//string begins with 0, 
 			//so it's ok that atof returns 0
@@ -202,7 +202,7 @@ bool ParseCmdLine(int argc, char* argv[], float &threshold, bool & matlabIndexin
 		else
 		{
 			//this doesn't throw exceptions, AKAIK
-			threshold = (float)atof(argv[counter]);
+			threshold = (double)atof(argv[counter]);
 
 			//the string does not include a 0, but atof returns 0. 
 			//string cannot be converted to threshold value

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -9,8 +9,8 @@ void SecondCallOnEmptyData()
 {
 	Persistence1D p;
 	vector<TPairedExtrema> pairs;
-	vector<int> min, max;
-	vector<float> data1, data2; 
+	vector<size_t> min, max;
+	vector<double> data1, data2; 
 
 	data1.push_back(1.0);
 	data1.push_back(2.0);
@@ -23,8 +23,8 @@ void SecondCallOnEmptyData()
 	p.RunPersistence(data2);
 	p.GetExtremaIndices(min, max);
 	p.GetPairedExtrema(pairs);
-	float minVal = p.GetGlobalMinimumValue();
-	int idx = p.GetGlobalMinimumIndex();
+	double minVal = p.GetGlobalMinimumValue();
+	size_t idx = p.GetGlobalMinimumIndex();
 	
 	assert(minVal==0);
 	assert(idx ==-1);
@@ -39,15 +39,15 @@ void MutliCallPersistence()
 {
 	Persistence1D p;
 	vector<TPairedExtrema> pairs;
-	vector<int> min, max;
-	vector<float> data1, data2; 
+	vector<size_t> min, max;
+	vector<double> data1, data2; 
 
 	data1.push_back(1.0);
 	data1.push_back(2.0);
 	data1.push_back(3.0);
 	data1.push_back(1.0);
 
-	data2 = vector<float>(data1);
+	data2 = vector<double>(data1);
 	data2.push_back(4.0);
 	data2.push_back(10.0);
 	data2.push_back(-5.0);
@@ -81,7 +81,7 @@ void MutliCallPersistence()
 
 	//now check the filters:
 	p.GetExtremaIndices(min, max, 10);
-	p.GetPairedExtrema(pairs, (float)2.1);
+	p.GetPairedExtrema(pairs, 2.1);
 	assert(p.GetGlobalMinimumValue()==-5.0);
 	assert(p.GetGlobalMinimumIndex()==6);
 	assert(min.size()==0);
@@ -96,8 +96,8 @@ void RunOnEmptyData()
 {
 	Persistence1D p;
 	vector<TPairedExtrema> pairs;
-	vector<int> min, max;
-	vector<float> data; 
+	vector<size_t> min, max;
+	vector<double> data; 
 
 	p.RunPersistence(data);
 
@@ -126,8 +126,8 @@ void CallsBeforeRuns()
 {
 	Persistence1D p;
 	vector<TPairedExtrema> pairs;
-	vector<int> min, max;
-	vector<float> data; 
+	vector<size_t> min, max;
+	vector<double> data; 
 
 	p.GetExtremaIndices(min, max);
 	assert(min.empty());
@@ -154,16 +154,16 @@ void TestInputSizeOne()
 {
 	Persistence1D p;
 	vector<TPairedExtrema> pairs;
-	vector<int> min, max;
+	vector<size_t> min, max;
 
-	vector<float> data; 
+	vector<double> data; 
 	data.push_back(10.0);
 
 	p.RunPersistence(data); 
 	p.GetPairedExtrema(pairs);
 	p.GetExtremaIndices(min, max);
-	int minIdx = p.GetGlobalMinimumIndex();
-	float minVal = p.GetGlobalMinimumValue();
+	size_t minIdx = p.GetGlobalMinimumIndex();
+	double minVal = p.GetGlobalMinimumValue();
 
 	assert(pairs.empty() && min.empty() && max.empty());
 	assert(minIdx==0);
@@ -177,17 +177,17 @@ void TestInputSizeTwo()
 {
 	Persistence1D p;
 	vector<TPairedExtrema> pairs;
-	vector<int> min, max;
+	vector<size_t> min, max;
 
-	vector<float> data; 
+	vector<double> data; 
 	data.push_back(10.0);
 	data.push_back(20.0);
 
 	p.RunPersistence(data); 
 	p.GetPairedExtrema(pairs);
 	p.GetExtremaIndices(min, max);
-	int minIdx = p.GetGlobalMinimumIndex();
-	float minVal = p.GetGlobalMinimumValue();
+	size_t minIdx = p.GetGlobalMinimumIndex();
+	double minVal = p.GetGlobalMinimumValue();
 
 	assert(pairs.empty() && min.empty() && max.empty());
 	assert(minIdx!=-1);
@@ -199,16 +199,16 @@ void TestInputSizeTwo()
 }
 void RandomizedTesting()
 {
-	vector<float> data; 
-	int size = rand() % 10000;
+	vector<double> data; 
+	size_t size = rand() % 10000;
 	data.reserve(size);
 
 	Persistence1D p;
 
 	//create data
-	for (int i = 0; i < size; i++)
+	for (size_t i = 0; i < size; i++)
 	{		
-		data.push_back((float)rand());
+		data.push_back((double)rand());
 	}
 
 	p.RunPersistence(data);
@@ -222,7 +222,7 @@ int main()
 	CallsBeforeRuns();
 	MutliCallPersistence();
 	SecondCallOnEmptyData();
-	for (int i = 0; i < 100; i++)
+	for (size_t i = 0; i < 100; i++)
 	{
 		RandomizedTesting();
 	}


### PR DESCRIPTION
As I wanted to use Persistence1D in a x64-compliled program, in which I'm using double type variables, I've converted all used data types to size_t (instead of int) and double (instead of float). Especially by using size_t it is possible to perform an analysis on much larger data sets.
Caveat: I've not dealt with the matlab part as I'm not using it.